### PR TITLE
Fix API host for server-side calls in Docker

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -13,6 +13,7 @@ RUN npm run build:client && npm run build:server
 # runtime image
 FROM node:20-alpine
 ENV NODE_ENV=production
+ENV API_HOSTNAME=http://api:8000
 WORKDIR /app
 COPY --from=build /app/inventorius-frontend/dist /app/dist
 COPY inventorius-frontend/public /app/public

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,6 +26,7 @@ services:
     environment:
       NODE_ENV: development
       PORT: "3001"
+      API_HOSTNAME: http://api:8000
     networks: [inventorius]
 
   nginx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       NODE_ENV: production
       PORT: "3001"
+      API_HOSTNAME: http://api:8000
     networks: [inventorius]
 
   nginx:

--- a/inventorius-frontend/src/server/entry.tsx
+++ b/inventorius-frontend/src/server/entry.tsx
@@ -20,7 +20,8 @@ import App from "../components/App";
 import { ApiClient } from "../api-client/api-client";
 import { version } from "os";
 
-const API_HOSTNAME = "http://localhost:8081";
+// Use API_HOSTNAME from env if available; fallback to docker service name
+const API_HOSTNAME = process.env.API_HOSTNAME || "http://api:8000";
 
 const doc = `
 Usage:


### PR DESCRIPTION
## Summary
- Allow server renderer to use configurable API host with default to Docker service
- Set API_HOSTNAME for frontend container in Docker configs
- Provide default API_HOSTNAME in frontend Dockerfile

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897b385a2fc8331b7dfa8da466611e1