### PR TITLE
Add explicit failing test for bin creation validation

### DIFF
--- a/inventorius-api/tests/test_bin_cost_per_case_none.py
+++ b/inventorius-api/tests/test_bin_cost_per_case_none.py
@@ -1,0 +1,7 @@
+from conftest import clientContext
+
+
+def test_bin_creation_with_none_cost_per_case():
+    with clientContext() as client:
+        resp = client.post('/api/bins', json={'id': 'BIN123456', 'props': {'cost_per_case': None}})
+        assert resp.status_code == 201


### PR DESCRIPTION
## Summary
- Reproduce API failure when creating a bin with invalid properties
- Expect 201 but API returns 400 due to `cost_per_case` being `None`

## Testing
- `pytest tests/test_bin_cost_per_case_none.py -q` *(fails: 400 != 201)*

------
https://chatgpt.com/codex/tasks/task_e_689cd021449c8331b3ef340daea882dc