### PR TITLE
Add placeholder manufacturing and traceability screens

### DIFF
--- a/inventorius-frontend/src/components/App.tsx
+++ b/inventorius-frontend/src/components/App.tsx
@@ -28,6 +28,12 @@ import Receive from "./Receive";
 import MoveItem from "./MoveItem";
 import Release from "./Release";
 import Audit from "./Audit";
+import MixtureDetail from "./MixtureDetail";
+import StepTemplateList from "./StepTemplateList";
+import StepTemplateDetail from "./StepTemplateDetail";
+import StepInstanceList from "./StepInstanceList";
+import StepInstanceDetail from "./StepInstanceDetail";
+import TraceabilityReport from "./TraceabilityReport";
 
 /**
  * Main app component
@@ -89,6 +95,24 @@ function App() {
                 </Route>
                 <Route path="/batch/:id">
                   <Batch />
+                </Route>
+                <Route path="/mixture/:id">
+                  <MixtureDetail />
+                </Route>
+                <Route exact path="/step-templates">
+                  <StepTemplateList />
+                </Route>
+                <Route path="/step-template/:id">
+                  <StepTemplateDetail />
+                </Route>
+                <Route exact path="/step-instances">
+                  <StepInstanceList />
+                </Route>
+                <Route path="/step-instance/:id">
+                  <StepInstanceDetail />
+                </Route>
+                <Route path="/traceability">
+                  <TraceabilityReport />
                 </Route>
                 <Route path="/receive">
                   <Receive />

--- a/inventorius-frontend/src/components/MixtureDetail.tsx
+++ b/inventorius-frontend/src/components/MixtureDetail.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { useParams } from "react-router-dom";
+
+import "../styles/MixtureDetail.css";
+
+function MixtureDetail() {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <section className="info-panel mixture-detail">
+      <div className="info-item">
+        <div className="info-item-title">Mixture Identifier</div>
+        <div className="info-item-description">
+          <span>{id}</span>
+          <span className="info-panel__hint">
+            Detailed lineage and bin activity will appear here.
+          </span>
+        </div>
+      </div>
+      <div className="info-item">
+        <div className="info-item-title">Component Batches</div>
+        <div className="info-item-description">
+          <p>
+            This placeholder will show the batches that were combined to form
+            the mixture along with their remaining quantities.
+          </p>
+        </div>
+      </div>
+      <div className="info-item">
+        <div className="info-item-title">Recent Activity</div>
+        <div className="info-item-description">
+          <p>
+            Activity such as draws, splits, and adjustments will be summarised
+            in this section to aid traceability.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default MixtureDetail;

--- a/inventorius-frontend/src/components/Navbar.tsx
+++ b/inventorius-frontend/src/components/Navbar.tsx
@@ -53,6 +53,20 @@ function Navbar({
       <NavLink className="navlink" to="/release">
         Release
       </NavLink>
+      <NavlinkDropdown text="Manufacturing">
+        <NavLink className="navlink" to="/step-templates">
+          Step Templates
+        </NavLink>
+        <NavLink className="navlink" to="/step-instances">
+          Step Instances
+        </NavLink>
+        <NavLink className="navlink" to="/traceability">
+          Traceability Report
+        </NavLink>
+        <NavLink className="navlink" to="/mixture/demo-mixture">
+          Mixture Detail
+        </NavLink>
+      </NavlinkDropdown>
       <NavLink className="navlink" to="/search">
         Search
       </NavLink>

--- a/inventorius-frontend/src/components/StepInstanceDetail.tsx
+++ b/inventorius-frontend/src/components/StepInstanceDetail.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { useParams } from "react-router-dom";
+
+import "../styles/StepInstances.css";
+
+function StepInstanceDetail() {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <section className="info-panel step-instance-detail">
+      <div className="info-item">
+        <div className="info-item-title">Instance</div>
+        <div className="info-item-description">
+          <span>{id}</span>
+          <p className="step-instance-detail__hint">
+            Execution metadata, operator assignments, and audit history will be
+            displayed here.
+          </p>
+        </div>
+      </div>
+      <div className="info-item">
+        <div className="info-item-title">Consumed Inputs</div>
+        <div className="info-item-description">
+          <p>
+            Placeholder rows will expand into a detailed list of batches and
+            mixtures that were drawn for this step.
+          </p>
+        </div>
+      </div>
+      <div className="info-item">
+        <div className="info-item-title">Produced Outputs</div>
+        <div className="info-item-description">
+          <p>
+            The outputs section will enumerate resulting batches and their
+            quantities for downstream tracking.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default StepInstanceDetail;

--- a/inventorius-frontend/src/components/StepInstanceList.tsx
+++ b/inventorius-frontend/src/components/StepInstanceList.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { generatePath, Link } from "react-router-dom";
+
+import "../styles/StepInstances.css";
+
+const placeholderInstances = [
+  { id: "inst-1001", template: "Blend Base Oils" },
+  { id: "inst-1002", template: "Infuse Botanicals" },
+  { id: "inst-1003", template: "Bottle Final Product" },
+];
+
+function StepInstanceList() {
+  return (
+    <section className="info-panel step-instance-list">
+      <div className="info-item">
+        <div className="info-item-title">Step Instances</div>
+        <div className="info-item-description">
+          <p>
+            Instances capture how a template was executed, including actual
+            inputs, outputs, and operator notes. This placeholder offers sample
+            rows that will eventually be replaced with API data.
+          </p>
+        </div>
+      </div>
+      {placeholderInstances.map((instance) => (
+        <div className="info-item" key={instance.id}>
+          <div className="info-item-title">{instance.template}</div>
+          <div className="info-item-description">
+            <span className="step-instance-list__identifier">{instance.id}</span>
+            <Link
+              className="action-link"
+              to={generatePath("/step-instance/:id", { id: instance.id })}
+            >
+              View instance
+            </Link>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export default StepInstanceList;

--- a/inventorius-frontend/src/components/StepTemplateDetail.tsx
+++ b/inventorius-frontend/src/components/StepTemplateDetail.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { useParams } from "react-router-dom";
+
+import "../styles/StepTemplates.css";
+
+function StepTemplateDetail() {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <section className="info-panel step-template-detail">
+      <div className="info-item">
+        <div className="info-item-title">Template</div>
+        <div className="info-item-description">
+          <span>{id}</span>
+          <p className="step-template-detail__hint">
+            Configure SKU requirements, default notes, and safety checks here.
+          </p>
+        </div>
+      </div>
+      <div className="info-item">
+        <div className="info-item-title">Expected Inputs</div>
+        <div className="info-item-description">
+          <p>
+            A structured editor will describe mandatory and optional input SKUs,
+            including quantity guidance for operators.
+          </p>
+        </div>
+      </div>
+      <div className="info-item">
+        <div className="info-item-title">Expected Outputs</div>
+        <div className="info-item-description">
+          <p>
+            Planned output SKUs and nominal quantities will be captured in this
+            section for quick reference during instance creation.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default StepTemplateDetail;

--- a/inventorius-frontend/src/components/StepTemplateList.tsx
+++ b/inventorius-frontend/src/components/StepTemplateList.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { generatePath, Link } from "react-router-dom";
+
+import "../styles/StepTemplates.css";
+
+const placeholderTemplates = [
+  { id: "tmpl-001", name: "Blend Base Oils" },
+  { id: "tmpl-002", name: "Infuse Botanicals" },
+  { id: "tmpl-003", name: "Bottle Final Product" },
+];
+
+function StepTemplateList() {
+  return (
+    <section className="info-panel step-template-list">
+      <div className="info-item">
+        <div className="info-item-title">Step Templates</div>
+        <div className="info-item-description">
+          <p>
+            Templates describe the expected inputs and outputs for repeated
+            manufacturing operations. This placeholder will list saved
+            templates and link to their detailed configuration screens.
+          </p>
+        </div>
+      </div>
+      {placeholderTemplates.map((template) => (
+        <div className="info-item" key={template.id}>
+          <div className="info-item-title">{template.name}</div>
+          <div className="info-item-description">
+            <span className="step-template-list__identifier">{template.id}</span>
+            <Link
+              className="action-link"
+              to={generatePath("/step-template/:id", { id: template.id })}
+            >
+              View template
+            </Link>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export default StepTemplateList;

--- a/inventorius-frontend/src/components/TraceabilityReport.tsx
+++ b/inventorius-frontend/src/components/TraceabilityReport.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+
+import "../styles/TraceabilityReport.css";
+
+function TraceabilityReport() {
+  return (
+    <section className="info-panel traceability-report">
+      <div className="info-item">
+        <div className="info-item-title">Traceability Report</div>
+        <div className="info-item-description">
+          <p>
+            Use this workspace to generate downstream usage reports for batches
+            and mixtures. Filters, date ranges, and output modes will be added
+            in future iterations.
+          </p>
+        </div>
+      </div>
+      <form className="traceability-report__form form">
+        <label className="traceability-report__field">
+          <span className="traceability-report__label form-label">
+            Batch or Mixture ID
+          </span>
+          <input
+            aria-label="Batch or mixture identifier"
+            className="traceability-report__input"
+            placeholder="e.g. BAT123 or Mx42"
+            type="text"
+          />
+        </label>
+        <label className="traceability-report__field">
+          <span className="traceability-report__label form-label">
+            Report Scope
+          </span>
+          <select aria-label="Report scope" className="traceability-report__input">
+            <option value="downstream">Downstream usage</option>
+            <option value="upstream">Upstream provenance</option>
+          </select>
+        </label>
+        <button className="traceability-report__submit" type="button">
+          Generate preview
+        </button>
+      </form>
+      <div className="traceability-report__preview">
+        <p>
+          Report results will render in this area once the backend endpoints are
+          connected.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export default TraceabilityReport;

--- a/inventorius-frontend/src/styles/MixtureDetail.css
+++ b/inventorius-frontend/src/styles/MixtureDetail.css
@@ -1,0 +1,15 @@
+.mixture-detail {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.mixture-detail .info-item-description {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.info-panel__hint {
+  color: #4b4b4b;
+  font-size: 0.9rem;
+}

--- a/inventorius-frontend/src/styles/StepInstances.css
+++ b/inventorius-frontend/src/styles/StepInstances.css
@@ -1,0 +1,22 @@
+.step-instance-list,
+.step-instance-detail {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.step-instance-list .info-item-description,
+.step-instance-detail .info-item-description {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.step-instance-list__identifier {
+  font-family: "Roboto Mono", monospace;
+  font-size: 0.9rem;
+}
+
+.step-instance-detail__hint {
+  color: #4b4b4b;
+  font-size: 0.9rem;
+}

--- a/inventorius-frontend/src/styles/StepTemplates.css
+++ b/inventorius-frontend/src/styles/StepTemplates.css
@@ -1,0 +1,22 @@
+.step-template-list,
+.step-template-detail {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.step-template-list .info-item-description,
+.step-template-detail .info-item-description {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.step-template-list__identifier {
+  font-family: "Roboto Mono", monospace;
+  font-size: 0.9rem;
+}
+
+.step-template-detail__hint {
+  color: #4b4b4b;
+  font-size: 0.9rem;
+}

--- a/inventorius-frontend/src/styles/TraceabilityReport.css
+++ b/inventorius-frontend/src/styles/TraceabilityReport.css
@@ -1,0 +1,43 @@
+.traceability-report {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.traceability-report__form {
+  gap: 1rem;
+}
+
+.traceability-report__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.traceability-report__input {
+  padding: 0.5rem;
+  border-radius: 0.3rem;
+  border: 1px solid #c1c1c1;
+}
+
+.traceability-report__submit {
+  align-self: flex-start;
+  margin-top: 1rem;
+  background-color: #26532b;
+  color: #fff;
+  border: none;
+  border-radius: 0.3rem;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.traceability-report__submit:hover,
+.traceability-report__submit:focus {
+  background-color: #1c3d20;
+}
+
+.traceability-report__preview {
+  background-color: #fff;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  box-shadow: 0 10px 20px -15px rgba(0, 0, 0, 0.3);
+}

--- a/inventorius-frontend/src/styles/TraceabilityReport.css
+++ b/inventorius-frontend/src/styles/TraceabilityReport.css
@@ -4,6 +4,7 @@
 }
 
 .traceability-report__form {
+  display: flex;
   gap: 1rem;
 }
 


### PR DESCRIPTION
## Summary
- add placeholder components for mixture, step template, step instance, and traceability report pages
- register routes for the new screens and surface navigation links via a manufacturing dropdown
- include basic responsive style stubs tailored to the placeholder layouts

## Testing
- npm test -- --runTestsByPath src/components/App.test.tsx *(fails: jest binary is not available in this repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c97f40288331973e8449d77021d7